### PR TITLE
Use static templatetag for CDN-compatible file paths

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ python:
   - 2.7
   - 3.3
 env:
-  - DJANGO_VERSION=1.3.7
   - DJANGO_VERSION=1.4.5
   - DJANGO_VERSION=1.5.1
 install:
@@ -22,7 +21,5 @@ after_success:
   - coveralls
 matrix:
   exclude:
-    - python: 3.3
-      env: DJANGO_VERSION=1.3.7
     - python: 3.3
       env: DJANGO_VERSION=1.4.5

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Django Mptt Admin
 Requirements
 ------------
 
-The package is tested with Django 1.3.7, 1.4.5 and 1.5.1, and Mptt 0.5.5. Also with Python 2.6 and 2.7.
+The package is tested with Django 1.4.5 and 1.5.1, and Mptt 0.5.5. Also with Python 2.6 and 2.7.
 
 Installation
 ------------

--- a/django_mptt_admin/templates/django_mptt_admin/change_list.html
+++ b/django_mptt_admin/templates/django_mptt_admin/change_list.html
@@ -1,17 +1,18 @@
 {% extends 'admin/change_list.html' %}
+{% load staticfiles %}
 
 {% block extrastyle %}
     {{ block.super }}
-    <link rel="stylesheet" href="{{ STATIC_URL }}django_mptt_admin/css/jqtree.css">
-    <link rel="stylesheet" href="{{ STATIC_URL }}django_mptt_admin/css/django_mptt_admin.css">
+    <link rel="stylesheet" href="{% static "django_mptt_admin/css/jqtree.css" %}">
+    <link rel="stylesheet" href="{% static "django_mptt_admin/css/django_mptt_admin.css" %}">
 {% endblock %}
 
 {% block extrahead %}
     {{ block.super }}
-    <script src="{{ STATIC_URL }}django_mptt_admin/js/jquery-1.9.1.min.js"></script>
-    <script src="{{ STATIC_URL }}django_mptt_admin/js/jquery.cookie.js"></script>
-    <script src="{{ STATIC_URL }}django_mptt_admin/js/tree.jquery.js"></script>
-    <script src="{{ STATIC_URL }}django_mptt_admin/js/django_mptt_admin.js"></script>
+    <script src="{% static "django_mptt_admin/js/jquery-1.9.1.min.js" %}"></script>
+    <script src="{% static "django_mptt_admin/js/jquery.cookie.js" %}"></script>
+    <script src="{% static "django_mptt_admin/js/tree.jquery.js" %}"></script>
+    <script src="{% static "django_mptt_admin/js/django_mptt_admin.js" %}"></script>
     <script>
         jQuery(function() {
             var auto_open = {{ tree_auto_open }};


### PR DESCRIPTION
Hi,

This small tweak adds CDN-compatibility to your django-mptt-admin project by using the `static` templatetag to dynamically build the paths to the static files based on the StaticFilesStorage backend defined in the project's settings.py.

Benefits of this are that CDN backends will work with the static assets, as will the extremely useful CachedStaticFilesStorage backend.

Downside is that it means compatibility is restricted to Django 1.4 or above. If you're keen to maintain 1.3.7 compatibility, I propose putting references to the staticfiles into two separate include files, which can then be conditionally included depending on django.VERSION[1]. I'm happy to make this further change if you'd like?

Cheers
