### PR TITLE
Fix ordering on jstree

### DIFF
--- a/django_mptt_admin/util.py
+++ b/django_mptt_admin/util.py
@@ -107,7 +107,7 @@ def get_tree_queryset(model, node_id=None, selected_node_id=None, max_level=None
         if not include_root:
             qs = qs.exclude(level=0)
 
-    return qs.order_by('lft')
+    return qs.order_by('lft').order_by('tree_id')
 
 
 def get_javascript_value(value):


### PR DESCRIPTION
JSON tree is ordered by lft field but not the tree_id field. This should be lft first then tree_id.
