### PR TITLE
Use MPTTModelAdmin for DjangoMpttAdmin

### DIFF
--- a/django_mptt_admin/admin.py
+++ b/django_mptt_admin/admin.py
@@ -5,13 +5,13 @@ from django.core.exceptions import PermissionDenied, SuspiciousOperation
 from django.core.urlresolvers import reverse
 from django.http import JsonResponse
 from django.template.response import TemplateResponse
-from django.contrib import admin
 from django.contrib.admin.options import csrf_protect_m
 from django.contrib.admin.views.main import ChangeList
 from django.conf.urls import url
 from django.contrib.admin.utils import unquote, quote
 from django.contrib.admin.options import IS_POPUP_VAR
 from django.db import transaction
+from mptt.admin import MPTTModelAdmin
 
 from . import util
 
@@ -250,5 +250,5 @@ class DjangoMpttAdminMixin(object):
         return javascript_catalog(request, domain='django', packages=['django_mptt_admin'])
 
 
-class DjangoMpttAdmin(DjangoMpttAdminMixin, admin.ModelAdmin):
+class DjangoMpttAdmin(DjangoMpttAdminMixin, MPTTModelAdmin):
     pass


### PR DESCRIPTION
Currently `DjangoMpttAdmin` uses `admin.ModelAdmin` (along with `DjangoMpttAdminMixin`) - however this isn't sufficient. django-mptt provides [MPTTModelAdmin](https://github.com/django-mptt/django-mptt/blob/0.8.3/mptt/admin.py#L24) which provides 2 things, fixes for mass deletions, and `TreeForeignKey` fixes.

Without this, when editing an object you see all possible options, in this example I'm editing the `/about/` page:

<img width="302" alt="without mpttmodeladmin" src="https://cloud.githubusercontent.com/assets/177332/14985306/da06fbfa-113e-11e6-95fa-8372b5491a52.png">

I can select child pages of `/about/`, which results in this when trying to save the object:

```
  File "/Users/tomkins/.virtualenvs/project/lib/python3.4/site-packages/mptt/managers.py", line 1202, in _move_root_node
    raise InvalidMove(_('A node may not be made a child of any of its descendants.'))
mptt.exceptions.InvalidMove: A node may not be made a child of any of its descendants.
```
However if we use `MPTTModelAdmin`:

<img width="302" alt="with mpttmodeladmin" src="https://cloud.githubusercontent.com/assets/177332/14985372/1affd406-113f-11e6-9925-cc2b543fcb71.png">

We can't select pages which would cause a problem.

Let me know if this is sufficient, or if additional testing is required.