### PR TITLE
Use the Django admin static tag for CSS / Javascript

### DIFF
--- a/django_mptt_admin/admin.py
+++ b/django_mptt_admin/admin.py
@@ -1,6 +1,7 @@
 from functools import update_wrapper
 
 from django.conf import settings
+from django.contrib.admin.templatetags.admin_static import static
 from django.core.exceptions import PermissionDenied, SuspiciousOperation
 from django.core.urlresolvers import reverse
 from django.http import JsonResponse
@@ -103,14 +104,14 @@ class DjangoMpttAdminMixin(object):
         media = super(DjangoMpttAdminMixin, self).media
 
         media.add_js([
-            'django_mptt_admin/jquery_namespace.js',
-            'django_mptt_admin/django_mptt_admin.js',
+            static('django_mptt_admin/jquery_namespace.js'),
+            static('django_mptt_admin/django_mptt_admin.js'),
         ])
 
         media.add_css(
             dict(
                 all=(
-                    'django_mptt_admin/django_mptt_admin.css',
+                    static('django_mptt_admin/django_mptt_admin.css'),
                 )
             )
         )

--- a/example_project/django_mptt_example/tests.py
+++ b/example_project/django_mptt_example/tests.py
@@ -1,9 +1,12 @@
 # coding=utf-8
+import itertools
 import os
 
 from django.test import TestCase
+from django.conf import settings
 from django.contrib.auth.models import User
 from django.contrib.admin.options import IS_POPUP_VAR
+from django.contrib.staticfiles import finders
 from django.core import serializers
 
 from django_webtest import WebTest
@@ -204,6 +207,19 @@ class DjangoMpttAdminWebTests(WebTest):
 
         # tree view
         self.app.get('/django_mptt_example/country/', status=403)
+
+    def test_staticfiles(self):
+        # find all static media used for this page
+        countries_page = self.app.get('/django_mptt_example/country/')
+        media = countries_page.context['media']
+
+        static_urls = itertools.chain(media._js, *media._css.values())
+
+        # go through all the static files used for this page
+        for static_url in static_urls:
+            static_file = static_url.replace(settings.STATIC_URL, '', 1)
+            # must return None - a static file can't be found as it's been hashed already
+            self.assertIsNone(finders.find(static_file))
 
 
 class DjangoMpttAdminTestCase(TestCase):

--- a/example_project/example_project/settings.py
+++ b/example_project/example_project/settings.py
@@ -1,3 +1,4 @@
+import os
 import sys
 
 from pathlib import Path
@@ -49,7 +50,9 @@ MIDDLEWARE_CLASSES = global_settings.MIDDLEWARE_CLASSES = [
 STATIC_URL = '/static/'
 ROOT_URLCONF = 'example_project.urls'
 
-STATIC_ROOT = str(BASE_DIR.joinpath('static'))
+STATIC_ROOT = os.environ['STATIC_ROOT']
+
+STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.ManifestStaticFilesStorage'
 
 SECRET_KEY = 'secret'
 

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,10 @@ deps =
     django19: Django>=1.9,<1.10
     django19: django-mptt==0.8.4
 commands =
+    python manage.py collectstatic --noinput --verbosity 0
     python manage.py test django_mptt_example
+setenv =
+    STATIC_ROOT = {envtmpdir}/static
 basepython =
     py27: python2.7
     py35: python3.5


### PR DESCRIPTION
If you use `ManifestStaticFilesStorage` for `STATICFILES_STORAGE`, the admin currently renders:

```html
<link href="/static/django_mptt_admin/django_mptt_admin.css" type="text/css" media="all" rel="stylesheet" />
<script type="text/javascript" src="/static/admin/js/core.84da04fcbfaf.js"></script>
<script type="text/javascript" src="/static/admin/js/vendor/jquery/jquery.min.f9c7afd05729.js"></script>
<script type="text/javascript" src="/static/admin/js/jquery.init.95b62fa19378.js"></script>
<script type="text/javascript" src="/static/admin/js/admin/RelatedObjectLookups.b3916e8770e8.js"></script>
<script type="text/javascript" src="/static/admin/js/actions.min.c8d91e1d05fe.js"></script>
<script type="text/javascript" src="/static/admin/js/urlify.72f9b26e3ecd.js"></script>
<script type="text/javascript" src="/static/admin/js/prepopulate.min.f4057ebb9b62.js"></script>
<script type="text/javascript" src="/static/admin/js/vendor/xregexp/xregexp.min.c95393b8ca4d.js"></script>
<script type="text/javascript" src="/static/django_mptt_admin/jquery_namespace.js"></script>
<script type="text/javascript" src="/static/django_mptt_admin/django_mptt_admin.js"></script>
```

If long expires headers are added to any files in /static/ - users aren't going to get any updated versions unless they force refresh on pages.

In Django 1.10, this will be fixed in `django.forms.widgets.Media` itself thanks to https://github.com/django/django/commit/cf546e11ac76c8dec527e39ff8ce8249a195ab42, however until then the Django admin static templatetag is needed.

The last commit should result in the following being rendered:

```html
<link href="/static/django_mptt_admin/django_mptt_admin.b5c5ab089acb.css" type="text/css" media="all" rel="stylesheet" />
<script type="text/javascript" src="/static/admin/js/core.84da04fcbfaf.js"></script>
<script type="text/javascript" src="/static/admin/js/vendor/jquery/jquery.min.f9c7afd05729.js"></script>
<script type="text/javascript" src="/static/admin/js/jquery.init.95b62fa19378.js"></script>
<script type="text/javascript" src="/static/admin/js/admin/RelatedObjectLookups.b3916e8770e8.js"></script>
<script type="text/javascript" src="/static/admin/js/actions.min.c8d91e1d05fe.js"></script>
<script type="text/javascript" src="/static/admin/js/urlify.72f9b26e3ecd.js"></script>
<script type="text/javascript" src="/static/admin/js/prepopulate.min.f4057ebb9b62.js"></script>
<script type="text/javascript" src="/static/admin/js/vendor/xregexp/xregexp.min.c95393b8ca4d.js"></script>
<script type="text/javascript" src="/static/django_mptt_admin/jquery_namespace.a27ca46ff167.js"></script>
<script type="text/javascript" src="/static/django_mptt_admin/django_mptt_admin.4be036f54449.js"></script>
```

I'm not sure of the best way of testing that all static files output the correct hashed name - this seemed to work best across multiple versions of Django.