### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/django_mptt_admin/admin.py
+++ b/django_mptt_admin/admin.py
@@ -90,7 +90,7 @@ class DjangoMpttAdminMixin(object):
             return url(
                 regex,
                 wrap(view, cacheable),
-                name='%s_%s_%s' % (
+                name='{0!s}_{1!s}_{2!s}'.format(
                     self.model._meta.app_label,
                     util.get_model_name(self.model),
                     url_name
@@ -180,7 +180,7 @@ class DjangoMpttAdminMixin(object):
 
     def get_admin_url(self, name, args=None):
         opts = self.model._meta
-        url_name = 'admin:%s_%s_%s' % (opts.app_label, util.get_model_name(self.model), name)
+        url_name = 'admin:{0!s}_{1!s}_{2!s}'.format(opts.app_label, util.get_model_name(self.model), name)
 
         return reverse(
             url_name,

--- a/example_project/django_mptt_example/tests.py
+++ b/example_project/django_mptt_example/tests.py
@@ -66,9 +66,9 @@ class DjangoMpttAdminWebTests(WebTest):
         africa = root['children'][0]
 
         if short_django_version >= (1, 9):
-            change_url = '/django_mptt_example/country/%d/change/' % africa_id
+            change_url = '/django_mptt_example/country/{0:d}/change/'.format(africa_id)
         else:
-            change_url = '/django_mptt_example/country/%d/' % africa_id
+            change_url = '/django_mptt_example/country/{0:d}/'.format(africa_id)
 
         self.assertEqual(
             africa,
@@ -76,7 +76,7 @@ class DjangoMpttAdminWebTests(WebTest):
                 label='Africa',
                 id=africa_id,
                 url=change_url,
-                move_url='/django_mptt_example/country/%d/move/' % africa_id,
+                move_url='/django_mptt_example/country/{0:d}/move/'.format(africa_id),
                 load_on_demand=True,
             )
         )
@@ -85,13 +85,13 @@ class DjangoMpttAdminWebTests(WebTest):
         self.assertFalse(hasattr(africa, 'children'))
 
         # -- load subtree
-        json_data = self.app.get('%s?node=%d' % (base_url, africa_id)).json
+        json_data = self.app.get('{0!s}?node={1:d}'.format(base_url, africa_id)).json
 
         self.assertEqual(len(json_data), 58)
         self.assertEqual(json_data[0]['label'], 'Algeria')
 
         # -- issue 8; selected node does not exist
-        self.app.get('%s?selected_node=9999999' % base_url)
+        self.app.get('{0!s}?selected_node=9999999'.format(base_url))
 
     def test_grid_view(self):
         # - get grid page
@@ -112,9 +112,9 @@ class DjangoMpttAdminWebTests(WebTest):
         afghanistan_id = Country.objects.get(name='Afghanistan').id
 
         if short_django_version >= (1, 9):
-            change_url = '/django_mptt_example/country/%d/change/' % afghanistan_id
+            change_url = '/django_mptt_example/country/{0:d}/change/'.format(afghanistan_id)
         else:
-            change_url = '/django_mptt_example/country/%d/' % afghanistan_id
+            change_url = '/django_mptt_example/country/{0:d}/'.format(afghanistan_id)
 
         self.assertEqual(first_row.find('a').attr('href'), change_url)
 
@@ -127,7 +127,7 @@ class DjangoMpttAdminWebTests(WebTest):
             csrf_token = countries_page.form['csrfmiddlewaretoken'].value
 
             response = self.app.post(
-                '/django_mptt_example/country/%d/move/' % source_id,
+                '/django_mptt_example/country/{0:d}/move/'.format(source_id),
                 dict(
                     csrfmiddlewaretoken=csrf_token,
                     target_id=target_id,
@@ -192,7 +192,7 @@ class DjangoMpttAdminWebTests(WebTest):
 
     def test_popup(self):
         # popup must return grid view
-        grid_page = self.app.get('/django_mptt_example/country/?%s=true' % IS_POPUP_VAR)
+        grid_page = self.app.get('/django_mptt_example/country/?{0!s}=true'.format(IS_POPUP_VAR))
 
         first_row = grid_page.pyquery('#result_list tbody tr').eq(0)
         self.assertEqual(first_row.find('td').eq(0).text(), 'Afghanistan')


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:mbraak:django-mptt-admin?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:mbraak:django-mptt-admin?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)