### PR TITLE
tree items label is now configurable

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/django_mptt_admin/admin.py
+++ b/django_mptt_admin/admin.py
@@ -40,7 +40,10 @@ class DjangoMpttAdminMixin(object):
     use_context_menu = False
 
     change_list_template = 'django_mptt_admin/grid_view.html'
-    change_tree_template=  'django_mptt_admin/change_list.html'
+    change_tree_template = 'django_mptt_admin/change_list.html'
+
+    # define which field of the model should be the label for tree items
+    item_label_field_name = 'None'
 
     @csrf_protect_m
     def changelist_view(self, request, extra_context=None):
@@ -84,6 +87,7 @@ class DjangoMpttAdminMixin(object):
         def wrap(view, cacheable=False):
             def wrapper(*args, **kwargs):
                 return self.admin_site.admin_view(view, cacheable)(*args, **kwargs)
+
             return update_wrapper(wrapper, view)
 
         def create_url(regex, url_name, view, cacheable=False):
@@ -99,11 +103,11 @@ class DjangoMpttAdminMixin(object):
 
         # prepend new urls to existing urls
         return [
-            create_url(r'^(.+)/move/$', 'move', self.move_view),
-            create_url(r'^tree_json/$', 'tree_json', self.tree_json_view),
-            create_url(r'^grid/$', 'grid', self.grid_view),
-            create_url(r'^jsi18n/$', 'jsi18n', self.i18n_javascript, cacheable=True)
-        ] + super(DjangoMpttAdminMixin, self).get_urls()
+                   create_url(r'^(.+)/move/$', 'move', self.move_view),
+                   create_url(r'^tree_json/$', 'tree_json', self.tree_json_view),
+                   create_url(r'^grid/$', 'grid', self.grid_view),
+                   create_url(r'^jsi18n/$', 'jsi18n', self.i18n_javascript, cacheable=True)
+               ] + super(DjangoMpttAdminMixin, self).get_urls()
 
     @property
     def media(self):
@@ -199,7 +203,7 @@ class DjangoMpttAdminMixin(object):
                 move_url=self.get_admin_url('move', (quote(pk),))
             )
 
-        return util.get_tree_from_queryset(qs, handle_create_node, max_level)
+        return util.get_tree_from_queryset(qs, handle_create_node, max_level, self.item_label_field_name)
 
     def tree_json_view(self, request):
         request.current_app = self.admin_site.name
@@ -229,7 +233,7 @@ class DjangoMpttAdminMixin(object):
         context = dict(tree_url=self.get_admin_url('changelist'))
         if extra_context:
             context.update(extra_context)
-        return super(DjangoMpttAdminMixin, self).changelist_view(request,context)
+        return super(DjangoMpttAdminMixin, self).changelist_view(request, context)
 
     def filter_tree_queryset(self, queryset, request):
         """
@@ -238,7 +242,7 @@ class DjangoMpttAdminMixin(object):
         return queryset
 
     def get_changeform_initial_data(self, request):
-        initial_data = super(DjangoMpttAdminMixin,self).get_changeform_initial_data(request=request)
+        initial_data = super(DjangoMpttAdminMixin, self).get_changeform_initial_data(request=request)
 
         if 'insert_at' in request.GET:
             initial_data[self.get_insert_at_field()] = request.GET.get('insert_at')
@@ -300,7 +304,8 @@ class FilterableDjangoMpttAdmin(DjangoMpttAdmin):
     def filter_tree_queryset(self, queryset, request):
         change_list = self.get_change_list_for_tree(request)
 
-        self.filter_specs, self.has_filters, remaining_lookup_params, filters_use_distinct = change_list.get_filters(request)
+        self.filter_specs, self.has_filters, remaining_lookup_params, filters_use_distinct = change_list.get_filters(
+            request)
 
         # Then, we let every list filter modify the queryset to its liking.
         qs = queryset

--- a/django_mptt_admin/util.py
+++ b/django_mptt_admin/util.py
@@ -3,7 +3,7 @@ import json
 import six
 
 
-def get_tree_from_queryset(queryset, on_create_node=None, max_level=None):
+def get_tree_from_queryset(queryset, on_create_node=None, max_level=None, item_label_field_name=None):
     """
     Return tree data that is suitable for jqTree.
     The queryset must be sorted by 'tree_id' and 'left' fields.
@@ -35,8 +35,10 @@ def get_tree_from_queryset(queryset, on_create_node=None, max_level=None):
             min_level = instance.level
 
         pk = getattr(instance, pk_attname)
+        label = getattr(instance, item_label_field_name, six.text_type(instance))
+
         node_info = dict(
-            label=six.text_type(instance),
+            label=label,
             id=serialize_id(pk)
         )
         if on_create_node:


### PR DESCRIPTION
Added a way to define which field (or property method) of the model instance to use as tree item labels.

Added `item_label_field_name` property to DjangoMpttAdminMixin.

** item_label_field_name possible values are**:
string: name of the model field or model property method to use as tree items label
None (default): model unicode used ad tree item label



Usage:
models.py

```
class MyMpttModel(MPTTModel):
    title = models.CharField(......

    @property
    def title_for_admin(self):
          return '%s %s' % (self.pk, self.title)
```

admin.py
```
class MyMpttModelAdminClass(MPTTModelAdmin):
    item_label_field_name = 'title_for_admin'


admin.site.register(MyMpttModel, MyMpttModelAdminClass)
```