### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/django_mptt_admin/admin.py
+++ b/django_mptt_admin/admin.py
@@ -292,8 +292,8 @@ class DjangoMpttAdminMixin(object):
                 return False
             else:
                 opts = self.model._meta
-                current_url = '%s:%s' % (match.app_name, match.url_name)
-                grid_url = 'admin:%s_%s_grid' % (opts.app_label, opts.model_name)
+                current_url = '{0!s}:{1!s}'.format(match.app_name, match.url_name)
+                grid_url = 'admin:{0!s}_{1!s}_grid'.format(opts.app_label, opts.model_name)
 
                 return current_url == grid_url
 

--- a/example_project/django_mptt_example/tests.py
+++ b/example_project/django_mptt_example/tests.py
@@ -243,12 +243,12 @@ class DjangoMpttAdminWebTests(WebTest):
         if short_django_version >= (1, 9):
             self.assertEqual(
                 country_node['url'],
-                "/django_mptt_example/country/%s/change/?_changelist_filters=continent%%3DEurope" % country_node['id']
+                "/django_mptt_example/country/{0!s}/change/?_changelist_filters=continent%3DEurope".format(country_node['id'])
             )
         else:
             self.assertEqual(
                 country_node['url'],
-                "/django_mptt_example/country/%s/?_changelist_filters=continent%%3DEurope" % country_node['id']
+                "/django_mptt_example/country/{0!s}/?_changelist_filters=continent%3DEurope".format(country_node['id'])
             )
 
         # check urls


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:mbraak:django-mptt-admin?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:mbraak:django-mptt-admin?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)