### PR TITLE
Support media class

### DIFF
--- a/django_mptt_admin/admin.py
+++ b/django_mptt_admin/admin.py
@@ -202,8 +202,6 @@ class DjangoMpttAdminMixin(object):
        ] + super(DjangoMpttAdminMixin, self).get_urls()
 
     def get_tree_media(self):
-        admin_media = super(DjangoMpttAdminMixin, self).media
-
         js = [
             "admin/js/jquery.init.js",
             static('django_mptt_admin/jquery_namespace.js'),
@@ -217,7 +215,7 @@ class DjangoMpttAdminMixin(object):
 
         tree_media = Media(js=js, css=css)
 
-        return admin_media + tree_media
+        return self.media + tree_media
 
     @csrf_protect_m
     @transaction.atomic()

--- a/docs/index.md
+++ b/docs/index.md
@@ -121,6 +121,10 @@ Also see the example project for a complete continent filter.
 
 ## Changelog
 
+**development**
+
+* Issue #270: support media class
+
 **0.7.1** (april 23 2019)
 
 * Issue #254: upgrade jqtree to 1.4.10


### PR DESCRIPTION
For example:

```
class MenuAdmin(DjangoMpttAdmin):
    class Media:
        js = ('fontawesome_5/js/all.min.js',)

        css = {
            'all': ('fontawesome_5/css/all.min.css',)
        }
```

Also see #268