### PR TITLE
Fix dnd padding

### DIFF
--- a/django_mptt_admin/static/django_mptt_admin/django_mptt_admin.css
+++ b/django_mptt_admin/static/django_mptt_admin/django_mptt_admin.css
@@ -165,6 +165,8 @@ span.jqtree-dragging {
     vertical-align: middle; }
   #tree ul.jqtree-tree ul.jqtree_common {
     margin-top: 0; }
+  #tree ul.jqtree-tree li.jqtree_common {
+    padding: 0; }
   #tree ul.jqtree-tree.jqtree-rtl .edit {
     margin-left: 0;
     margin-right: 0.5em; }

--- a/docs/index.md
+++ b/docs/index.md
@@ -121,6 +121,10 @@ Also see the example project for a complete continent filter.
 
 ## Changelog
 
+**development**
+
+* Issue #276: fix movement during drag-and-drop
+
 **0.7.2** (october 19 2019)
 
 * Issue #270: support media class (thanks to Sencer H.)

--- a/frontend/django_mptt_admin.scss
+++ b/frontend/django_mptt_admin.scss
@@ -25,6 +25,10 @@
             margin-top: 0;
         }
 
+        li.jqtree_common {
+            padding: 0;
+        }
+
         &.jqtree-rtl {
             .edit {
                 margin-left: 0;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,7 @@
     "scripts": {
         "build": "node-sass django_mptt_admin.scss -o ../django_mptt_admin/static/django_mptt_admin/ && webpack --mode production",
         "sass": "node-sass django_mptt_admin.scss -o ../django_mptt_admin/static/django_mptt_admin/",
-        "webpack": "webpack --mode development",
+        "webpack": "webpack --mode development --watch",
         "lint": "eslint django_mptt_admin.ts"
     },
     "repository": {


### PR DESCRIPTION
During drag-and-drop the tree nodes move a few pixels. Fix this by setting padding to 0.