### PR TITLE
Use manifest storage in tests

### DIFF
--- a/example_project/django_mptt_example/tests/base_playwright_testcase.py
+++ b/example_project/django_mptt_example/tests/base_playwright_testcase.py
@@ -1,9 +1,9 @@
-from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 from django.conf import settings
+from django.test import LiveServerTestCase
 from .playwright_page import PlaywrightPage
 
 
-class BasePlaywrightTestCase(StaticLiveServerTestCase):
+class BasePlaywrightTestCase(LiveServerTestCase):
     def setUp(self):
         super().setUp()
 

--- a/example_project/example_project/settings.py
+++ b/example_project/example_project/settings.py
@@ -81,3 +81,12 @@ ALLOWED_HOSTS = ["*"]
 
 if "COVERAGE" in os.environ:
     DJANGO_MPTT_ADMIN_COVERAGE_JS = True
+
+STORAGES = {
+    "default": {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
+    },
+    "staticfiles": {
+        "BACKEND": "django.contrib.staticfiles.storage.ManifestStaticFilesStorage",
+    },
+}


### PR DESCRIPTION
Use ManifestStaticFilesStorage in the example project. This will hopefull catch errors with collectstatic.